### PR TITLE
Update ts-loader to 6.2.0.

### DIFF
--- a/apps/CardHero.NetCoreApp.TypeScript/package.json
+++ b/apps/CardHero.NetCoreApp.TypeScript/package.json
@@ -45,7 +45,7 @@
 		"source-map-loader": "0.2.4",
 		"style-loader": "1.0.0",
 		"terser-webpack-plugin": "2.1.2",
-		"ts-loader": "6.1.2",
+		"ts-loader": "6.2.0",
 		"typescript": "3.6.3",
 		"webpack": "4.41.0",
 		"webpack-bundle-analyzer": "3.5.2",
@@ -61,6 +61,6 @@
     "test": "cross-env CI=true react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint ./src/",
-    "watch": "webpack --watch --info-verbosity verbose"
+    "watch": "cross-env NODE_ENV=development webpack --watch --info-verbosity verbose"
   }
 }

--- a/apps/CardHero.NetCoreApp.TypeScript/yarn.lock
+++ b/apps/CardHero.NetCoreApp.TypeScript/yarn.lock
@@ -10478,10 +10478,10 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-loader@6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.1.2.tgz#ff6bc767334970226438949fbde2e211147a1325"
-  integrity sha512-dudxFKm0Ellrg/gLNlu+97/UgwvoMK0SdUVImPUSzq3IcRUVtShylZvcMX+CgvCQL1BEKb913NL0gAP1GA/OFw==
+ts-loader@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.0.tgz#52d3993ecbc5474c1513242388e1049da0fce880"
+  integrity sha512-Da8h3fD+HiZ9GvZJydqzk3mTC9nuOKYlJcpuk+Zv6Y1DPaMvBL+56GRzZFypx2cWrZFMsQr869+Ua2slGoLxvQ==
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"


### PR DESCRIPTION
This should bring faster build times when using watch API.

See:
 * https://github.com/TypeStrong/ts-loader/releases/tag/v6.2.0