### PR TITLE
#89: Only send the session key to the client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ healthchecksdb
 
 # Custom ignores
 *.eslintcache
+/apps/CardHero.NetCoreApp.TypeScript/data

--- a/CardHero.sln
+++ b/CardHero.sln
@@ -54,7 +54,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardHero.Data.SqlServer", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardHero.Data.SqlServerGenerator", "src\CardHero.Data.SqlServerGenerator\CardHero.Data.SqlServerGenerator.csproj", "{5DFA6D89-1691-4A77-96A1-958B2D7EF2CD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CardHero.Data.SqlServer.DependencyInjection", "src\CardHero.Data.SqlServer.DependencyInjection\CardHero.Data.SqlServer.DependencyInjection.csproj", "{33ED1E2C-5C2E-4C73-B6B9-B2298125C2DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardHero.Data.SqlServer.DependencyInjection", "src\CardHero.Data.SqlServer.DependencyInjection\CardHero.Data.SqlServer.DependencyInjection.csproj", "{33ED1E2C-5C2E-4C73-B6B9-B2298125C2DA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardHero.AspNetCore.Authentication.FileSystem", "src\CardHero.AspNetCore.Authentication.FileSystem\CardHero.AspNetCore.Authentication.FileSystem.csproj", "{9FEC7BAE-DE13-4D5D-BDE5-0CA9D8863189}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -128,6 +130,10 @@ Global
 		{33ED1E2C-5C2E-4C73-B6B9-B2298125C2DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33ED1E2C-5C2E-4C73-B6B9-B2298125C2DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33ED1E2C-5C2E-4C73-B6B9-B2298125C2DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FEC7BAE-DE13-4D5D-BDE5-0CA9D8863189}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FEC7BAE-DE13-4D5D-BDE5-0CA9D8863189}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FEC7BAE-DE13-4D5D-BDE5-0CA9D8863189}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FEC7BAE-DE13-4D5D-BDE5-0CA9D8863189}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,6 +155,7 @@ Global
 		{85101338-D3B8-4E4A-9C16-D0C9700D28F6} = {A4871F8E-B9E1-4927-8B0E-C191FD2E8A25}
 		{5DFA6D89-1691-4A77-96A1-958B2D7EF2CD} = {A4871F8E-B9E1-4927-8B0E-C191FD2E8A25}
 		{33ED1E2C-5C2E-4C73-B6B9-B2298125C2DA} = {A4871F8E-B9E1-4927-8B0E-C191FD2E8A25}
+		{9FEC7BAE-DE13-4D5D-BDE5-0CA9D8863189} = {A4871F8E-B9E1-4927-8B0E-C191FD2E8A25}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E6E117CB-BCCA-4426-B653-65D15CEA4F96}

--- a/apps/CardHero.NetCoreApp.TypeScript/CardHero.NetCoreApp.TypeScript.csproj
+++ b/apps/CardHero.NetCoreApp.TypeScript/CardHero.NetCoreApp.TypeScript.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\CardHero.AspNetCore.Authentication.FileSystem\CardHero.AspNetCore.Authentication.FileSystem.csproj" />
     <ProjectReference Include="..\..\src\CardHero.Core.Abstractions\CardHero.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\CardHero.Core.Models\CardHero.Core.Models.csproj" />
     <ProjectReference Include="..\..\src\CardHero.Core.SqlServer\CardHero.Core.SqlServer.csproj" />

--- a/apps/CardHero.NetCoreApp.TypeScript/Startup.cs
+++ b/apps/CardHero.NetCoreApp.TypeScript/Startup.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 
+using CardHero.AspNetCore.Authentication.FileSystem;
 using CardHero.Core.SqlServer.Web;
 
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -12,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 using WebMarkupMin.AspNetCore3;
 
@@ -19,12 +22,14 @@ namespace CardHero.NetCoreApp.TypeScript
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+        private readonly IConfiguration _configuration;
+        private readonly IWebHostEnvironment _environment;
 
-        public IConfiguration Configuration { get; }
+        public Startup(IConfiguration configuration, IWebHostEnvironment environment)
+        {
+            _configuration = configuration;
+            _environment = environment;
+        }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -40,6 +45,9 @@ namespace CardHero.NetCoreApp.TypeScript
                     x.LogoutPath = "/SignOut";
 
                     x.Cookie.Name = ".ch";
+                    x.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict;
+                    x.ExpireTimeSpan = TimeSpan.FromTicks(TimeSpan.TicksPerDay * 28);
+                    x.SlidingExpiration = true;
 
                     x.Events.OnRedirectToLogin = context =>
                     {
@@ -54,17 +62,40 @@ namespace CardHero.NetCoreApp.TypeScript
 
                         return Task.CompletedTask;
                     };
+
+                    if (_environment.IsDevelopment())
+                    {
+                        var baseDirectory = Path.Combine(_environment.ContentRootPath, "data", nameof(JsonFileSystemTicketStore));
+
+                        if (!Directory.Exists(baseDirectory))
+                        {
+                            Directory.CreateDirectory(baseDirectory);
+                        }
+
+                        x.SessionStore = new JsonFileSystemTicketStore(
+                            LoggerFactory.Create(x =>
+                            {
+                                x.AddConfiguration(_configuration);
+                                x.AddDebug();
+                                x.AddConsole();
+                            }).CreateLogger<JsonFileSystemTicketStore>(),  //HACK: create empy logger without DI
+                            new FileSystemTicketStoreOptions
+                            {
+                                BaseDirectory = baseDirectory,
+                            }
+                        );
+                    }
                 })
             ;
 
-            var localAuthOptions = Configuration.GetSection("Authentication:Local").Get<LocalAuthenticationOptions>();
+            var localAuthOptions = _configuration.GetSection("Authentication:Local").Get<LocalAuthenticationOptions>();
             if (localAuthOptions != null)
             {
                 localAuthOptions.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 authBuilder.AddLocalAuthentication(localAuthOptions);
             }
 
-            var githubAuthOptions = Configuration.GetSection("Authentication:GitHub").Get<GitHubAuthenticationOptions>();
+            var githubAuthOptions = _configuration.GetSection("Authentication:GitHub").Get<GitHubAuthenticationOptions>();
             if (githubAuthOptions != null)
             {
                 githubAuthOptions.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -116,9 +147,9 @@ namespace CardHero.NetCoreApp.TypeScript
                 })
             ;
 
-            services.AddCardHeroDataSqlServer(Configuration);
+            services.AddCardHeroDataSqlServer(_configuration);
 
-            services.AddCardHeroSqlServerDbContext(Configuration);
+            services.AddCardHeroSqlServerDbContext(_configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/CardHero.AspNetCore.Authentication.FileSystem/CardHero.AspNetCore.Authentication.FileSystem.csproj
+++ b/src/CardHero.AspNetCore.Authentication.FileSystem/CardHero.AspNetCore.Authentication.FileSystem.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\..\analyzers\stylecop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\analyzers\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/src/CardHero.AspNetCore.Authentication.FileSystem/Cookies/JsonFileSystemTicketStore.cs
+++ b/src/CardHero.AspNetCore.Authentication.FileSystem/Cookies/JsonFileSystemTicketStore.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Logging;
+
+namespace CardHero.AspNetCore.Authentication.FileSystem
+{
+    /// <summary>
+    /// Ticket store using JSON files on the file system.
+    /// Useful for debugging and seeing what's in the session but not recommended for production use as the session is stored unencrypte.
+    /// </summary>
+    public class JsonFileSystemTicketStore : ITicketStore
+    {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+        {
+            AllowTrailingCommas = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            WriteIndented = true,
+        };
+
+        private readonly ILogger<JsonFileSystemTicketStore> _logger;
+        private readonly FileSystemTicketStoreOptions _options;
+        private readonly string _baseDirectory;
+
+        public JsonFileSystemTicketStore(ILogger<JsonFileSystemTicketStore> logger, FileSystemTicketStoreOptions options)
+        {
+            _logger = logger;
+
+            _options = options;
+            _baseDirectory = options.BaseDirectory;
+        }
+
+        Task ITicketStore.RemoveAsync(string key)
+        {
+            _logger.LoggerRemove(key);
+
+            var path = GetPath(key);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        async Task ITicketStore.RenewAsync(string key, AuthenticationTicket ticket)
+        {
+            _logger.LoggerRenew(key);
+
+            await SaveAuthenticationTicketAsync(key, ticket);
+        }
+
+        async Task<AuthenticationTicket> ITicketStore.RetrieveAsync(string key)
+        {
+            _logger.LoggerRetrieveove(key);
+
+            var path = GetPath(key);
+
+            if (File.Exists(path))
+            {
+                CardHeroAuthenticationTicketModel model;
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+                {
+                    model = await JsonSerializer.DeserializeAsync<CardHeroAuthenticationTicketModel>(fs, options: _jsonSerializerOptions);
+                }
+
+                var claims = model.Claims.Select(x => new Claim(x.Key, x.Value)).ToArray();
+                var identity = new ClaimsIdentity(claims, model.AuthenticationType, model.ClaimNameType, model.ClaimRoleType);
+                var principal = new ClaimsPrincipal(identity);
+                var properties = new AuthenticationProperties(model.AuthenticationPropertiesItems, model.AuthenticationPropertiesParameters);
+                var ticket = new AuthenticationTicket(principal, properties, model.AuthenticationScheme);
+
+                return ticket;
+            }
+
+            return null;
+        }
+
+        async Task<string> ITicketStore.StoreAsync(AuthenticationTicket ticket)
+        {
+            var key = Guid.NewGuid().ToString();
+
+            _logger.LoggerStore(key);
+
+            await SaveAuthenticationTicketAsync(key, ticket);
+
+            return key;
+        }
+
+        private string GetPath(string key)
+        {
+            return Path.Combine(_baseDirectory, key + ".json");
+        }
+
+        private async Task SaveAuthenticationTicketAsync(string key, AuthenticationTicket ticket)
+        {
+            var path = GetPath(key);
+            var identity = ticket.Principal.Identity as ClaimsIdentity;
+            var model = new CardHeroAuthenticationTicketModel
+            {
+                AuthenticationScheme = ticket.AuthenticationScheme,
+                AuthenticationPropertiesItems = ticket.Properties.Items,
+                AuthenticationPropertiesParameters = ticket.Properties.Parameters,
+
+                AuthenticationType = identity?.AuthenticationType,
+                ClaimNameType = identity?.NameClaimType,
+                ClaimRoleType = identity?.RoleClaimType,
+
+                Claims = ticket.Principal.Claims.ToDictionary(x => x.Type, x => x.Value),
+            };
+
+            using (var fs = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                await JsonSerializer.SerializeAsync(fs, model, options: _jsonSerializerOptions);
+            }
+        }
+    }
+}

--- a/src/CardHero.AspNetCore.Authentication.FileSystem/Logging/JsonFileSystemTicketStoreLoggerExtensions.cs
+++ b/src/CardHero.AspNetCore.Authentication.FileSystem/Logging/JsonFileSystemTicketStoreLoggerExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+using CardHero.AspNetCore.Authentication.FileSystem;
+
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal static class JsonFileSystemTicketStoreLoggerExtensions
+    {
+        private const LogLevel DefaultLogLevel = LogLevel.Information;
+
+        private static readonly Action<ILogger<JsonFileSystemTicketStore>, string, Exception> _removeLogger = LoggerMessage.Define<string>(
+            DefaultLogLevel,
+            new EventId(1, nameof(ITicketStore.RemoveAsync)),
+            "Removing session: {Key}"
+        );
+
+        private static readonly Action<ILogger<JsonFileSystemTicketStore>, string, Exception> _renewLogger = LoggerMessage.Define<string>(
+            DefaultLogLevel,
+            new EventId(2, nameof(ITicketStore.RenewAsync)),
+            "Renewing session: {Key}"
+        );
+
+        private static readonly Action<ILogger<JsonFileSystemTicketStore>, string, Exception> _retrieveLogger = LoggerMessage.Define<string>(
+            DefaultLogLevel,
+            new EventId(3, nameof(ITicketStore.RetrieveAsync)),
+            "Retrieving session: {Key}"
+        );
+
+        private static readonly Action<ILogger<JsonFileSystemTicketStore>, string, Exception> _storeLogger = LoggerMessage.Define<string>(
+            DefaultLogLevel,
+            new EventId(4, nameof(ITicketStore.StoreAsync)),
+            "Storing session: {Key}"
+        );
+
+        public static void LoggerRemove(this ILogger<JsonFileSystemTicketStore> logger, string key)
+        {
+            _removeLogger(logger, key, null);
+        }
+
+        public static void LoggerRenew(this ILogger<JsonFileSystemTicketStore> logger, string key)
+        {
+            _renewLogger(logger, key, null);
+        }
+
+        public static void LoggerRetrieveove(this ILogger<JsonFileSystemTicketStore> logger, string key)
+        {
+            _retrieveLogger(logger, key, null);
+        }
+
+        public static void LoggerStore(this ILogger<JsonFileSystemTicketStore> logger, string key)
+        {
+            _storeLogger(logger, key, null);
+        }
+    }
+}

--- a/src/CardHero.AspNetCore.Authentication.FileSystem/Models/CardHeroAuthenticationTicketModel.cs
+++ b/src/CardHero.AspNetCore.Authentication.FileSystem/Models/CardHeroAuthenticationTicketModel.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace CardHero.AspNetCore.Authentication.FileSystem
+{
+    internal class CardHeroAuthenticationTicketModel
+    {
+        public string AuthenticationScheme { get; set; }
+
+        public string AuthenticationType { get; set; }
+
+        public string ClaimNameType { get; set; }
+
+        public string ClaimRoleType { get; set; }
+
+        public IDictionary<string, string> AuthenticationPropertiesItems { get; set; }
+
+        public IDictionary<string, object> AuthenticationPropertiesParameters { get; set; }
+
+        public IDictionary<string, string> Claims { get; set; }
+    }
+}

--- a/src/CardHero.AspNetCore.Authentication.FileSystem/Options/FileSystemTicketStoreOptions.cs
+++ b/src/CardHero.AspNetCore.Authentication.FileSystem/Options/FileSystemTicketStoreOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace CardHero.AspNetCore.Authentication.FileSystem
+{
+    public class FileSystemTicketStoreOptions
+    {
+        /// <summary>
+        /// Base directory of where to store sessions.
+        /// </summary>
+        public string BaseDirectory { get; set; }
+    }
+}


### PR DESCRIPTION
This stores the session related data onto a folder in the file system.

The cookie is now 307 bytes instead of ~417 bytes.